### PR TITLE
Remove unnecessary whitespace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: 'Container Action Template'
 description: 'Get started with Container actions'
 author: 'GitHub'
-inputs: 
+inputs:
   myInput:
     description: 'Input to use'
     default: 'world'


### PR DESCRIPTION
## Description
This pull request removes unnecessary spaces after the 'inputs:' label in the form template.

## Why?
This unnecessary space can cause unnecessary differences when users remove it while using the template.

## Impact
This change does not have any impact on the functionality of the system.
