### PR TITLE
Update Dependabot Grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,21 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    groups:
+      docker-minor:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions-minor:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,12 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
+
+permissions:
+  contents: read
 
 jobs:
   test-docker:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,31 +1,28 @@
-name: Lint Code Base
+name: Lint Codebase
 
 on:
   pull_request:
-    branches:
-      - main
   push:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
-    name: Lint Code Base
+    name: Lint Codebase
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      packages: read
-      statuses: write
 
     steps:
       - name: Checkout
         id: checkout
         uses: actions/checkout@v4
 
-      - name: Lint Code Base
+      - name: Lint Codebase
         id: super-linter
         uses: super-linter/super-linter/slim@v5
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_ALL_CODEBASE: true


### PR DESCRIPTION
This PR groups dependabot updates into smaller numbers of PRs based on semantic version updates (e.g. dev dependencies for NPM are grouped for minor/patch updates). It also includes several small clarifications in comments.